### PR TITLE
Closes #5

### DIFF
--- a/src/pod/babashka/instaparse.clj
+++ b/src/pod/babashka/instaparse.clj
@@ -113,7 +113,7 @@
                          {"name" "parses"}
                          {"name" "failure?" "code" "(defn failure? [x] (boolean (:pod.babashka.instaparse/failure x)))"}
                          ;; register client side transit handlers when pod is loaded. Implementation detail.
-                         {"name" "reg-transit-handlers-foo"
+                         {"name" "-reg-transit-handlers"
                           "code"  (reg-transit-handlers)}]}]}))
 
 (def regex-read-handler (transit/read-handler re-pattern))
@@ -137,6 +137,7 @@
 
 (defn serialize [x]
   (clojure.walk/prewalk serialize- x))
+
 
 (defn write-transit [v]
   (let [baos (java.io.ByteArrayOutputStream.)]

--- a/src/pod/babashka/instaparse.clj
+++ b/src/pod/babashka/instaparse.clj
@@ -111,10 +111,9 @@
                          {"name" "parser" #_#_"code" parser-wrapper}
                          {"name" "parse"}
                          {"name" "parses"}
-                         {"name" "failure?" "code" "(defn failure? [x] (boolean (:pod.babashka.instaparse/failure x)))"}]}
-                 ;; register client side transit handlers when pod is loaded
-                 {:name "not.for.use"
-                  :vars [{"name" "reg-transit-handlers"
+                         {"name" "failure?" "code" "(defn failure? [x] (boolean (:pod.babashka.instaparse/failure x)))"}
+                         ;; register client side transit handlers when pod is loaded
+                         {"name" "reg-transit-handlers"
                           "code"  (reg-transit-handlers)}]}]}))
 
 (def regex-read-handler (transit/read-handler re-pattern))

--- a/src/pod/babashka/instaparse.clj
+++ b/src/pod/babashka/instaparse.clj
@@ -112,8 +112,8 @@
                          {"name" "parse"}
                          {"name" "parses"}
                          {"name" "failure?" "code" "(defn failure? [x] (boolean (:pod.babashka.instaparse/failure x)))"}
-                         ;; register client side transit handlers when pod is loaded
-                         {"name" "reg-transit-handlers"
+                         ;; register client side transit handlers when pod is loaded. Implementation detail.
+                         {"name" "reg-transit-handlers-foo"
                           "code"  (reg-transit-handlers)}]}]}))
 
 (def regex-read-handler (transit/read-handler re-pattern))

--- a/src/pod/babashka/instaparse.clj
+++ b/src/pod/babashka/instaparse.clj
@@ -33,6 +33,23 @@
 (defn read [stream]
   (bencode/read-bencode stream))
 
+(def regex-key (str ::regex))
+
+(defn reg-transit-handlers
+  []
+  (format
+  "
+(babashka.pods/add-transit-read-handler!
+    \"%s\"
+    re-pattern)
+
+(babashka.pods/add-transit-write-handler!
+  #{java.util.regex.Pattern}
+  \"%s\"
+  str)
+" 
+   regex-key regex-key))
+
 (def parsers
   (atom {}))
 
@@ -94,13 +111,22 @@
                          {"name" "parser" #_#_"code" parser-wrapper}
                          {"name" "parse"}
                          {"name" "parses"}
-                         {"name" "failure?" "code" "(defn failure? [x] (boolean (:pod.babashka.instaparse/failure x)))"}]}]}))
+                         {"name" "failure?" "code" "(defn failure? [x] (boolean (:pod.babashka.instaparse/failure x)))"}]}
+                 ;; register client side transit handlers when pod is loaded
+                 {:name "not.for.use"
+                  :vars [{"name" "reg-transit-handlers"
+                          "code"  (reg-transit-handlers)}]}]}))
+
+(def regex-read-handler (transit/read-handler re-pattern))
+
+(def regex-write-handler (transit/write-handler regex-key str))
 
 (defn read-transit [^String v]
   (transit/read
    (transit/reader
     (java.io.ByteArrayInputStream. (.getBytes v "utf-8"))
-    :json)))
+    :json
+    {:handlers {regex-key regex-read-handler}})))
 
 (defn auto-seq? [x]
   (instance? instaparse.auto_flatten_seq.AutoFlattenSeq x))
@@ -115,7 +141,9 @@
 
 (defn write-transit [v]
   (let [baos (java.io.ByteArrayOutputStream.)]
-    (transit/write (transit/writer baos :json) v)
+    (transit/write (transit/writer baos
+                                   :json
+                                   {:handlers {java.util.regex.Pattern regex-write-handler}}) v)
     (.toString baos "utf-8")))
 
 (defn -main [& _args]

--- a/test.clj
+++ b/test.clj
@@ -76,3 +76,12 @@
 (when-not (= "executable" (System/getProperty "org.graalvm.nativeimage.kind"))
     (shutdown-agents)
     (System/exit 0))
+
+(def regex-grammar-parser
+  (insta/parser
+   "S = A B
+    A = 'a'
+    B = #'b'"))
+
+;; would throw exception without regex serialization fix for #5
+(assert (insta/failure? (insta/parse regex-grammar-parser "ac")))


### PR DESCRIPTION
I called the new ns the pod exposes 'not.for.use' since as I understand it, it's purpose is to cause `reg-transit-handlers` to be evaluated at load-pod time (while *pod-id* is bound in babashka.pods); but it does not need to be called after that - in fact throws an exception.
Example taken from here https://github.com/babashka/tools-deps-native/blob/master/src/borkdude/tdn/pod.clj