### PR TITLE
Expose instaparse.core/span fn

### DIFF
--- a/script/compile
+++ b/script/compile
@@ -12,7 +12,7 @@ export PATH=$GRAALVM_HOME/bin:$PATH
 
 clojure -T:build uber
 
-if [ ! -f "$GRAALVM_HOME/bin/native-image" && -f "$GRAALVM_HOME/bin/gu" ]; then
+if [[ ! -f "$GRAALVM_HOME/bin/native-image" && -f "$GRAALVM_HOME/bin/gu" ]]; then
     "$GRAALVM_HOME/bin/gu" install native-image
 fi
 

--- a/script/compile
+++ b/script/compile
@@ -12,7 +12,9 @@ export PATH=$GRAALVM_HOME/bin:$PATH
 
 clojure -T:build uber
 
-"$GRAALVM_HOME/bin/gu" install native-image
+if [ ! -f "$GRAALVM_HOME/bin/native-image" && -f "$GRAALVM_HOME/bin/gu" ]; then
+    "$GRAALVM_HOME/bin/gu" install native-image
+fi
 
 args=(-jar "pod-babashka-instaparse.jar"
       -H:Name=pod-babashka-instaparse

--- a/src/pod/babashka/instaparse.clj
+++ b/src/pod/babashka/instaparse.clj
@@ -86,12 +86,16 @@
     (-> (apply insta/parses p opts)
         mark-failure)))
 
+(defn span [tree]
+  (insta/span tree))
+
 (def lookup*
   {'pod.babashka.instaparse
    {#_#_'-parser -parser
     'parse parse
     'parses parses
     'parser -parser
+    'span span
     #_#_'-call-parser -call-parser}})
 
 (defn lookup [var]
@@ -111,6 +115,7 @@
                          {"name" "parser" #_#_"code" parser-wrapper}
                          {"name" "parse"}
                          {"name" "parses"}
+                         {"name" "span"}
                          {"name" "failure?" "code" "(defn failure? [x] (boolean (:pod.babashka.instaparse/failure x)))"}
                          ;; register client side transit handlers when pod is loaded. Implementation detail.
                          {"name" "-reg-transit-handlers"


### PR DESCRIPTION
Closes #7 

e7a30ef9041103d4bdc21f81772ec14e442134ca is here because the GraalVM folks removed the `gu` tool in recent releases and `native-image` appears to be built-in now.