### PR TITLE
Fix span and failure? fns

### DIFF
--- a/src/pod/babashka/instaparse.clj
+++ b/src/pod/babashka/instaparse.clj
@@ -69,25 +69,21 @@
                                     p #_(fn [s]
                                           (-call-parser p s)))))))
 
-(defn mark-failure [x]
-  (if (insta/failure? x)
-    (assoc x ::failure true)
-    x))
-
 (defn parse [ref & opts]
   (let [id (::id ref)
         p (get @parsers id)]
-    (-> (apply insta/parse p opts)
-        mark-failure)))
+    (apply insta/parse p opts)))
 
 (defn parses [ref & opts]
   (let [id (::id ref)
         p (get @parsers id)]
-    (-> (apply insta/parses p opts)
-        mark-failure)))
+    (apply insta/parses p opts)))
 
 (defn span [tree]
   (insta/span tree))
+
+(defn failure? [result]
+  (insta/failure? result))
 
 (def lookup*
   {'pod.babashka.instaparse
@@ -96,6 +92,7 @@
     'parses parses
     'parser -parser
     'span span
+    'failure? failure?
     #_#_'-call-parser -call-parser}})
 
 (defn lookup [var]
@@ -115,8 +112,8 @@
                          {"name" "parser" #_#_"code" parser-wrapper}
                          {"name" "parse"}
                          {"name" "parses"}
-                         {"name" "failure?" "code" "(defn failure? [x] (boolean (:pod.babashka.instaparse/failure x)))"}
                          {"name" "span" "arg-meta" "true"}
+                         {"name" "failure?" "arg-meta" "true"}
                          ;; register client side transit handlers when pod is loaded. Implementation detail.
                          {"name" "-reg-transit-handlers"
                           "code"  (reg-transit-handlers)}]}]}))

--- a/src/pod/babashka/instaparse.clj
+++ b/src/pod/babashka/instaparse.clj
@@ -115,8 +115,8 @@
                          {"name" "parser" #_#_"code" parser-wrapper}
                          {"name" "parse"}
                          {"name" "parses"}
-                         {"name" "span"}
                          {"name" "failure?" "code" "(defn failure? [x] (boolean (:pod.babashka.instaparse/failure x)))"}
+                         {"name" "span" "arg-meta" "true"}
                          ;; register client side transit handlers when pod is loaded. Implementation detail.
                          {"name" "-reg-transit-handlers"
                           "code"  (reg-transit-handlers)}]}]}))
@@ -143,12 +143,12 @@
 (defn serialize [x]
   (clojure.walk/prewalk serialize- x))
 
-
 (defn write-transit [v]
   (let [baos (java.io.ByteArrayOutputStream.)]
     (transit/write (transit/writer baos
                                    :json
-                                   {:handlers {java.util.regex.Pattern regex-write-handler}}) v)
+                                   {:handlers {java.util.regex.Pattern regex-write-handler}
+                                    :transform transit/write-meta}) v)
     (.toString baos "utf-8")))
 
 (defn -main [& _args]


### PR DESCRIPTION
I got the test.chuck test suite running under babashka and it revealed some issues.

1. `span` needs argument metadata to be sent to the pod, and those arguments originally come from `parse` return values, so we need pod->client return value metadata enabled as well. f5822b60639a52b592637854bb38405d7fc5ebcb does this.
1. `mark-failure` wasn't working because its argument wasn't a `clojure.lang.Associative` which it was calling `assoc` on. I fixed this by enabling argument metadata for the `failure?` fn as well and then removed the babashka-specific handling of that.

There will be an upcoming PR for instaparse-bb that implements some related fixes in there as well.